### PR TITLE
paper dependency issue fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "@tensorflow/tfjs-converter": "^1.7.0",
     "@tensorflow/tfjs-core": "^1.7.0",
     "face-api.js": "^0.22.1",
-    "paper": "file:third_party/paper",
+    "paper": "^0.12.1",
     "stats.js": "^0.17.0"
   },
   "scripts": {
-    "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open ",
+    "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open --no-source-maps",
     "build": "cross-env NODE_ENV=production parcel build index.html --public-url ./",
     "build-camera": "cross-env NODE_ENV=production parcel build camera.html --public-url ./",
     "lint": "eslint .",


### PR DESCRIPTION
The paper dependency was throwing some errors due to the version issue. Have updated with the latest version of the paper and made it versioning dynamic for the same. 